### PR TITLE
Fixes environment variable name

### DIFF
--- a/lib/lambda-stack.ts
+++ b/lib/lambda-stack.ts
@@ -10,7 +10,7 @@ export class MyLambdaStack extends cdk.Stack {
         runtime: Runtime.NODEJS_12_X, //using node for this, but can easily use python or other
         handler: 'handler.handler',
         code: Code.fromAsset(path.join(__dirname, 'lambda')), //resolving to ./lambda directory
-        environment: { "stageName": stageName } //inputting stagename
+        environment: { "stage": stageName } //inputting stagename
       });
     }
     


### PR DESCRIPTION
In the handler code, it uses env.stage. Changing this to match it, otherwise lambda shows undefined.

Thanks for the repo!